### PR TITLE
Fix Aroma1997's Mining World compatibility with default config. 

### DIFF
--- a/src/main/java/li/cil/bedrockores/common/config/Settings.java
+++ b/src/main/java/li/cil/bedrockores/common/config/Settings.java
@@ -115,7 +115,7 @@ public final class Settings {
     @Config.RequiresMcRestart
     public static String[] defaultDimensionTypes = {
             DimensionType.OVERWORLD.getName().toLowerCase(Locale.US),
-            "miningworld" // Aroma1997
+            "MINING_WORLD" // Aroma1997
     };
 
     @Config.LangKey(Constants.CONFIG_ORE_MASK_USES_ALPHA)

--- a/src/main/resources/assets/bedrockores/config/_example.json
+++ b/src/main/resources/assets/bedrockores/config/_example.json
@@ -99,7 +99,7 @@
     },
     "dimensionFilter": "whitelist",
     "dimensionSelector": "type",
-    "dimension": [ "overworld", "miningworld" ],
+    "dimension": [ "overworld", "MINING_WORLD" ],
     "biomeFilter": "whitelist",
     "biomeSelector": "id",
     "biome": [ "*" ],


### PR DESCRIPTION
DImension type changed to "MINING_WORLD", as seems to be the default now.